### PR TITLE
fix: revert css updates for lists

### DIFF
--- a/src/tailwind.css
+++ b/src/tailwind.css
@@ -34,6 +34,11 @@
   ::file-selector-button {
     border-color: var(--color-gray-200, currentcolor);
   }
+  ul,
+  ol {
+    list-style: revert;
+    padding: revert;
+  }
 }
 
 /* Dark mode colors. */


### PR DESCRIPTION
Seems like #59 had an unintentional change with lists. Adding in revert calls for list-style and padding to get them looking correct again.

Current deployed version
![CleanShot 2025-04-29 at 10 34 07](https://github.com/user-attachments/assets/e6ea6df0-8f1b-4bf8-923c-c245e9e77047)

With updates
![CleanShot 2025-04-29 at 10 34 29](https://github.com/user-attachments/assets/16094588-7c56-4cd3-abc9-712ea3a5fc99)
