### PR TITLE
feat: document internal security communication channels

### DIFF
--- a/src/content/docs/compliance/information-security-policy.md
+++ b/src/content/docs/compliance/information-security-policy.md
@@ -55,6 +55,9 @@ Code Town will implement and maintain organizational controls by:
   and standards to protect information.
 - Documented procedures: Maintaining clear procedures for security incident
   management, business continuity, and disaster recovery.
+- Security communication: Keeping employees informed of security practices,
+  emerging threats, and compliance obligations through the channels and cadence
+  described in Security Communication below.
 
 ### People Controls
 
@@ -107,6 +110,36 @@ assets by:
 - Backup and recovery: Conducting regular backups of critical data and testing
   recovery procedures to ensure business continuity.
 
+### Security Communication
+
+Code Town maintains multiple channels for internal security communication so
+that all employees stay informed about security practices, current threats, and
+compliance obligations:
+
+- Security hub: This handbook is the canonical source for security policies,
+  standards, and procedures. Every policy in the Compliance section is published
+  here and is available to all employees and contractors.
+- Security announcements: The `#security-announcements` Discord channel carries
+  security alerts, advisories, incident notifications, and notices of policy
+  changes. All employees and contractors are members.
+- Direct notification: For findings that require prompt action, the Security
+  Officer notifies affected team members directly and initiates response per the
+  Incident Response Policy.
+
+The Security Officer (or designated security-responsible employee) posts a
+security update to `#security-announcements` on at least a monthly cadence. Each
+update covers:
+
+- Changes to security policies published in this handbook.
+- Emerging threats relevant to Code Town's stack, drawn from the review
+  described in the Threat Intelligence Policy.
+- Changes to compliance obligations that affect employee responsibilities.
+- Lessons learned from any security incident since the previous update.
+
+Updates prioritize material reflecting recent incidents, newly published or
+revised policies, and changes in assessed risk. Announcements remain in the
+channel history, which serves as the record of security communication.
+
 ## Compliance and Enforcement
 
 Compliance with this policy is mandatory for all employees, contractors, and
@@ -130,4 +163,5 @@ Reviews must consider changes in the regulatory landscape.
 
 | **Review Date**   | **Approver** |
 | ----------------- | ------------ |
+| July 29, 2026     | Eric Seidel  |
 | November 25, 2025 | Eric Seidel  |

--- a/src/content/docs/compliance/information-security-policy.md
+++ b/src/content/docs/compliance/information-security-policy.md
@@ -116,9 +116,10 @@ Code Town maintains multiple channels for internal security communication so
 that all employees stay informed about security practices, current threats, and
 compliance obligations:
 
-- Security hub: This handbook is the canonical source for security policies,
-  standards, and procedures. Every policy in the Compliance section is published
-  here and is available to all employees and contractors.
+- Security hub: Security policies, standards, and procedures are authored and
+  version controlled in this handbook and kept in sync with the Oneleet portal,
+  so employees and contractors can review them in either location. Employees
+  review and sign the policies that apply to their role in Oneleet.
 - Security announcements: The `#security-announcements` Discord channel carries
   security alerts, advisories, incident notifications, and notices of policy
   changes. All employees and contractors are members.
@@ -130,7 +131,7 @@ The Security Officer (or designated security-responsible employee) posts a
 security update to `#security-announcements` on at least a monthly cadence. Each
 update covers:
 
-- Changes to security policies published in this handbook.
+- Changes to security policies since the previous update.
 - Emerging threats relevant to Code Town's stack, drawn from the review
   described in the Threat Intelligence Policy.
 - Changes to compliance obligations that affect employee responsibilities.

--- a/src/content/docs/compliance/threat-intelligence-policy.md
+++ b/src/content/docs/compliance/threat-intelligence-policy.md
@@ -52,8 +52,10 @@ internal team documentation.
 
 ### Sharing and Communication
 
-Relevant threat intelligence findings will be shared with the team via a
-designated Discord channel. The monthly review summary should include:
+Relevant threat intelligence findings will be shared with the team via the
+`#security-announcements` Discord channel, as described in the Security
+Communication section of the Information Security Policy. The monthly review
+summary should include:
 
 - A brief summary of sources checked
 - Any notable findings and their assessed relevance to Code Town
@@ -99,6 +101,7 @@ Reviews must consider changes in the regulatory landscape.
 
 ### Review Log
 
-| Review Date  | Approver    |
-| ------------ | ----------- |
-| June 9, 2026 | Eric Seidel |
+| Review Date   | Approver    |
+| ------------- | ----------- |
+| July 29, 2026 | Eric Seidel |
+| June 9, 2026  | Eric Seidel |


### PR DESCRIPTION
## Summary

Names the channels employees actually get security information through, which
the ISO control on internal security communication requires and no policy
previously stated. Adds a Security Communication section to the Information
Security Policy covering three channels, this handbook as the security hub,
`#security-announcements` for alerts and advisories, and direct notification for
findings needing prompt action, plus a monthly cadence w/ a named owner and
defined update contents.

The Threat Intelligence Policy already promised a monthly summary to "a
designated Discord channel" that was never named, leaving that cadence
unauditable. I pointed it at `#security-announcements` rather than standing up a
second channel, so both policies describe one cadence and the channel history
serves as the evidence record for each.

`#security-announcements` needs to exist w/ all employees in it before this
merges, and the monthly post becomes a standing obligation on the Security
Officer.

## Testing

- `astro check && astro build` passes, internal link validation clean