### PR TITLE
ci(dependabot): add cooldown + split npm group to minor/patch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,7 +9,20 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    # Wait for a release to age before we ever see the PR, so the ecosystem has
+    # time to flag a broken or compromised version first. Security updates
+    # bypass the cooldown automatically.
+    cooldown:
+      default-days: 5
     groups:
+      # Actions are referenced by floating major tags (e.g. @v6), which already
+      # track minor/patch silently. We deliberately do NOT request minor/patch
+      # updates here: doing so makes Dependabot pin the ref (@v6 -> @v6.4.0)
+      # instead of leaving the floating tag alone. We only want a PR when a new
+      # major ships.
       gha-deps:
         patterns:
           - "*"
@@ -17,7 +30,22 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 10
+    labels:
+      - "dependencies"
+    cooldown:
+      default-days: 5
+      semver-major-days: 14
+      semver-minor-days: 7
+      semver-patch-days: 3
     groups:
+      # Minor/patch only, so a major arrives as its own PR instead of riding
+      # along in the group. A single incompatible major (e.g. typescript 7 vs
+      # the @astrojs/check peer range) otherwise fails `npm install` and blocks
+      # every other update in the group.
       npm-deps:
         patterns:
           - "*"
+        update-types:
+          - "minor"
+          - "patch"


### PR DESCRIPTION
Ports the Dependabot config from `shorebirdtech/shorebird` ([#2485](https://github.com/shorebirdtech/shorebird/pull/2485), plus the #2565 and #2579 follow-ups) to this repo.

### Why

#210 is the motivating case. It groups three updates, and one of them — `typescript` 6.0.3 → 7.0.2 — violates the `@astrojs/check` peer range:

```
npm error ERESOLVE could not resolve
npm error While resolving: @astrojs/check@0.9.10
npm error Found: typescript@7.0.2
npm error Could not resolve dependency:
npm error peer typescript@"^5.0.0 || ^6.0.0" from @astrojs/check@0.9.10
```

`@astrojs/check@0.9.10` is the latest published version and still caps at TS 6, so there's no upgrade that resolves it — we have to wait for upstream. Meanwhile `npm install` fails before anything compiles, taking the perfectly fine `astro` 7.1.6 → 7.2.0 and `@astrojs/starlight` 0.41.5 → 0.41.7 updates down with it.

I verified locally that reverting only `typescript` to `^6.0.3` resolves cleanly against the PR's lockfile with the other two bumps in place.

### What changed

- **npm group requests only `minor` + `patch`**, so majors arrive as individual PRs. Under this config #210 would have been two PRs: astro + starlight (green, mergeable) and a solo TypeScript 7 major to close until upstream catches up.
- **Release cooldown** — ages a release before we ever see the PR, giving the ecosystem time to flag a broken or compromised version. Security updates bypass it automatically. Also would have delayed this TS 7 major by 14 days, which is often enough for peer ranges to widen.
- **`open-pull-requests-limit: 10` and the `dependencies` label**, matching `_shorebird`.

The `github-actions` entry deliberately keeps no `update-types`: every action here is referenced by a floating major tag (`actions/checkout@v7`, `withastro/action@v6`, …), and requesting minor/patch would make Dependabot pin the ref (`@v6` → `@v6.4.0`) instead of leaving the tag alone. It also takes only `default-days`, since the `semver-*` cooldown keys aren't supported for that ecosystem — that's what shorebird#2565 fixed.

### Follow-up

Dependabot reads config from the default branch, so once this lands, comment `@dependabot recreate` on #210 to regenerate it without the TypeScript bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)